### PR TITLE
Feature/coverage

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,3 +28,8 @@ jobs:
       run: |
         pip install pytest
         pytest -v
+    - name: Test coverage
+      run: |
+        pip install coverage
+        coverage run -m pytest ./tests
+        coverage report -m

--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,7 @@ fruity/logs/
 
 # Custom includes
 !conf/env/
+
+# Weird numbered files that keep coming back, reporting the status of pip installs
+2.5
+2.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ tqdm==4.66.1
 hydra-core==1.3.2
 hydra-colorlog==1.2.0
 rich==13.7.0
+pytest==7.4.4
+coverage==7.4.0


### PR DESCRIPTION
Closes #13. Use coverage to test for the percentage of code covered by the ./tests/ folder. There is a very small chance that this will create a merge conflict, since pull request #41 also made changes to the tests.yaml file.